### PR TITLE
Use the WordPress HTTP API to check response code

### DIFF
--- a/embed-gutenberg-block-google-maps.php
+++ b/embed-gutenberg-block-google-maps.php
@@ -129,6 +129,11 @@ function renderGutenbergMapEmbedblock( $attributes ) {
     // Look for a cached response code for the map URL.
     $httpcode = get_transient( 'pantheon_google_map_block_url_response_code' );
 
+    // Ensure the status code from cache is an integer.
+    if( false !== $httpcode ) {
+        $httpcode = intval( $httpcode );
+    }
+
     // If the response code is not found in the cache
     // Or the current response code is not a 200
     if( false === $httpcode || $httpcode !== 200 ) {


### PR DESCRIPTION
Closes #25.

Use the [WordPress HTTP API](https://developer.wordpress.org/plugins/http-api/) instead of `curl` to check the response code of the map URL.

Cache the map URL response code in a transient to avoid request on each page load.